### PR TITLE
Trigger Checks Workflow On Pull Requests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,6 @@
 name: Checks
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
Add pull_request to the Checks workflow triggers so CI runs on PRs, not just pushes.