### PR TITLE
♻️ Migrate CLI from Argparse to Click

### DIFF
--- a/brightwheel_photos/cli.py
+++ b/brightwheel_photos/cli.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-import argparse
-import getpass
 import json
 from datetime import datetime, timezone
 import io
 import os
 import sys
 from urllib.parse import urlparse
+import click
 import piexif
 from PIL import Image
 import requests
@@ -16,76 +15,54 @@ from dotenv import load_dotenv
 
 def main():
     """Runs brightwheel_photos cli"""
-    # Load environment variables from .env file
     load_dotenv()
+    cli()  # pylint: disable=no-value-for-parameter
 
-    parser = argparse.ArgumentParser(description="Download photos from Brightwheel")
-    parser.add_argument(
-        "--email",
-        default=os.getenv("BRIGHTWHEEL_EMAIL"),
-        help="email used for Brightwheel account (or set BRIGHTWHEEL_EMAIL in .env)",
-    )
-    parser.add_argument(
-        "--password",
-        default=os.getenv("BRIGHTWHEEL_PASSWORD"),
-        help="password used for Brightwheel account (or set BRIGHTWHEEL_PASSWORD in .env)",
-    )
-    parser.add_argument(
-        "--directory",
-        default=os.getenv("BRIGHTWHEEL_DIRECTORY", "./photos"),
-        help="directory in which to save the photos (or set BRIGHTWHEEL_DIRECTORY in .env)",
-    )
-    parser.add_argument(
-        "--student-id",
-        default=os.getenv("BRIGHTWHEEL_STUDENT_ID"),
-        help="Brightwheel student ID (or set BRIGHTWHEEL_STUDENT_ID in .env)",
-    )
-    parser.add_argument("--since", help="Skip any photos before a given YYYY-MM-DD")
-    parser.add_argument("--before", help="Skip any photos after a given YYYY-MM-DD")
-    parser.add_argument(
-        "--skip-existing",
-        action="store_true",
-        help="Skip any existing photos or videos",
-    )
-    args = parser.parse_args()
 
-    # Validate required credentials
-    if not args.email:
-        print(
-            "Error: Email is required. Provide via --email or BRIGHTWHEEL_EMAIL in .env",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    if not args.directory:
-        print(
-            "Error: Directory is required. Provide via --directory or BRIGHTWHEEL_DIRECTORY in .env",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    if not args.password:
-        try:
-            args.password = getpass.getpass("Enter password: ")
-        except KeyboardInterrupt:
-            print("\nCancelled by user.", file=sys.stderr)
-            sys.exit(130)
-        except EOFError:
-            print("Error: Password required but not provided and no interactive terminal available.", file=sys.stderr)
-            sys.exit(1)
-        if not args.password:
-            print("Error: Password is required.", file=sys.stderr)
-            sys.exit(1)
-
-    os.makedirs(args.directory, exist_ok=True)
+@click.command(help="Download photos from Brightwheel")
+@click.option(
+    "--email",
+    envvar="BRIGHTWHEEL_EMAIL",
+    required=True,
+    help="email used for Brightwheel account (or set BRIGHTWHEEL_EMAIL in .env)",
+)
+@click.option(
+    "--password",
+    envvar="BRIGHTWHEEL_PASSWORD",
+    prompt=True,
+    hide_input=True,
+    help="password used for Brightwheel account (or set BRIGHTWHEEL_PASSWORD in .env)",
+)
+@click.option(
+    "--directory",
+    envvar="BRIGHTWHEEL_DIRECTORY",
+    default="./photos",
+    show_default=True,
+    help="directory in which to save the photos (or set BRIGHTWHEEL_DIRECTORY in .env)",
+)
+@click.option(
+    "--student-id",
+    envvar="BRIGHTWHEEL_STUDENT_ID",
+    default=None,
+    help="Brightwheel student ID (or set BRIGHTWHEEL_STUDENT_ID in .env)",
+)
+@click.option("--since", default=None, help="Skip any photos before a given YYYY-MM-DD")
+@click.option("--before", default=None, help="Skip any photos after a given YYYY-MM-DD")
+@click.option(
+    "--skip-existing", is_flag=True, help="Skip any existing photos or videos"
+)
+def cli(email, password, directory, student_id, since, before, skip_existing):
+    """Runs brightwheel_photos cli"""
+    os.makedirs(directory, exist_ok=True)
     with requests.Session() as s:
         try:
-            twofacode = trigger_2fa(s, args.email, args.password)
-            login(s, args.email, args.password, twofacode)
+            twofacode = trigger_2fa(s, email, password)
+            login(s, email, password, twofacode)
         except requests.HTTPError as err:
             if [err.response.status_code == 401]:
                 print("Login failed", file=sys.stderr)
                 sys.exit(1)
         # try to find student_id if not provided
-        student_id = args.student_id
         if not student_id:
             students = find_students(s)
             if len(students) > 1:
@@ -105,25 +82,25 @@ def main():
         # find and save all photos for the student
         try:
             with open(f"student-{student_id}-activities.jsonl", "w") as raw_fh:
-                for activity in find_activities(s, student_id, args.since):
+                for activity in find_activities(s, student_id, since):
                     json.dump(activity, raw_fh)
                     raw_fh.write("\n")
                     # Skip if less than since argument
-                    if args.since:
+                    if since:
                         event_date = datetime.strptime(
                             activity["event_date"][0:10], "%Y-%m-%d"
                         )
-                        since = datetime.strptime(args.since, "%Y-%m-%d")
-                        if event_date < since:
+                        since_date = datetime.strptime(since, "%Y-%m-%d")
+                        if event_date < since_date:
                             continue
 
                     # Skip if greater than before argument
-                    if args.before:
+                    if before:
                         event_date = datetime.strptime(
                             activity["event_date"][0:10], "%Y-%m-%d"
                         )
-                        before = datetime.strptime(args.before, "%Y-%m-%d")
-                        if event_date > before:
+                        before_date = datetime.strptime(before, "%Y-%m-%d")
+                        if event_date > before_date:
                             continue
 
                     if activity["media"] is not None:
@@ -132,8 +109,8 @@ def main():
                         created_at = datetime.strptime(
                             activity["created_at"], "%Y-%m-%dT%H:%M:%S.%f%z"
                         )
-                        if args.skip_existing is True and os.path.isfile(
-                            f"{args.directory}/{path}.jpg"
+                        if skip_existing is True and os.path.isfile(
+                            f"{directory}/{path}.jpg"
                         ):
                             print(
                                 f"skipping download of photo {created_at}, file exists already"
@@ -147,7 +124,7 @@ def main():
                         exif = build_exif_bytes(image, created_at, comment)
                         image.save(
                             "{directory}/{path}.jpg".format(
-                                directory=args.directory, path=path
+                                directory=directory, path=path
                             ),
                             exif=exif,
                         )
@@ -158,8 +135,8 @@ def main():
                         created_at = datetime.strptime(
                             activity["created_at"], "%Y-%m-%dT%H:%M:%S.%f%z"
                         )
-                        if args.skip_existing is True and os.path.isfile(
-                            f"{args.directory}/{path}.mp4"
+                        if skip_existing is True and os.path.isfile(
+                            f"{directory}/{path}.mp4"
                         ):
                             print(
                                 f"skipping download of video {created_at}, file exists already"
@@ -173,7 +150,7 @@ def main():
                             r = vs.get(url, stream=True)
                             with open(
                                 "{directory}/{path}.mp4".format(
-                                    directory=args.directory, path=path
+                                    directory=directory, path=path
                                 ),
                                 "wb",
                             ) as f:

--- a/brightwheel_photos/cli.py
+++ b/brightwheel_photos/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import getpass
 import json
 from datetime import datetime, timezone
 import io
@@ -55,18 +56,24 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
-    if not args.password:
-        print(
-            "Error: Password is required. Provide via --password or BRIGHTWHEEL_PASSWORD in .env",
-            file=sys.stderr,
-        )
-        sys.exit(1)
     if not args.directory:
         print(
             "Error: Directory is required. Provide via --directory or BRIGHTWHEEL_DIRECTORY in .env",
             file=sys.stderr,
         )
         sys.exit(1)
+    if not args.password:
+        try:
+            args.password = getpass.getpass("Enter password: ")
+        except KeyboardInterrupt:
+            print("\nCancelled by user.", file=sys.stderr)
+            sys.exit(130)
+        except EOFError:
+            print("Error: Password required but not provided and no interactive terminal available.", file=sys.stderr)
+            sys.exit(1)
+        if not args.password:
+            print("Error: Password is required.", file=sys.stderr)
+            sys.exit(1)
 
     os.makedirs(args.directory, exist_ok=True)
     with requests.Session() as s:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "certifi>=2024.7.4",
+    "click>=8.4.2",
     "idna>=3.15",
     "piexif>=1.1.3",
     "Pillow>=10.1.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,102 @@
+import os
+
+from click.testing import CliRunner
+
+from brightwheel_photos import cli as cli_module
+from brightwheel_photos.cli import cli
+
+
+def stub_network(monkeypatch):
+    monkeypatch.setattr(cli_module, "trigger_2fa", lambda s, email, password: None)
+    monkeypatch.setattr(
+        cli_module, "login", lambda s, email, password, twofacode=None: None
+    )
+    monkeypatch.setattr(cli_module, "find_students", lambda s: [{"object_id": "stu-1"}])
+    monkeypatch.setattr(
+        cli_module, "find_activities", lambda s, student_id, since=None: iter([])
+    )
+
+
+def test_missing_email_exits_2_with_message():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--password", "secret"], env={"BRIGHTWHEEL_EMAIL": ""})
+
+    assert result.exit_code == 2
+    assert "Missing option '--email'" in result.output
+
+
+def test_directory_env_var_precedence(tmp_path, monkeypatch):
+    stub_network(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    env_dir = tmp_path / "from-env"
+    result = runner.invoke(
+        cli,
+        ["--email", "a@b.com", "--password", "secret"],
+        env={"BRIGHTWHEEL_DIRECTORY": str(env_dir)},
+    )
+    assert result.exit_code == 0
+    assert env_dir.is_dir()
+
+    flag_dir = tmp_path / "from-flag"
+    result = runner.invoke(
+        cli,
+        ["--email", "a@b.com", "--password", "secret", "--directory", str(flag_dir)],
+        env={"BRIGHTWHEEL_DIRECTORY": str(env_dir)},
+    )
+    assert result.exit_code == 0
+    assert flag_dir.is_dir()
+
+
+def test_skip_existing_flag(tmp_path, monkeypatch):
+    import requests
+
+    stub_network(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    activity = {
+        "media": {"image_url": "https://schools.mybrightwheel.com/media/abc123.jpg"},
+        "video_info": None,
+        "created_at": "2024-01-02T03:04:05.000000+00:00",
+        "note": None,
+    }
+    monkeypatch.setattr(
+        cli_module,
+        "find_activities",
+        lambda s, student_id, since=None: iter([activity]),
+    )
+
+    def get_raises_if_called(self, *args, **kwargs):
+        raise RuntimeError("network should not be reached when skipping")
+
+    monkeypatch.setattr(requests.Session, "get", get_raises_if_called)
+
+    os.makedirs("photos", exist_ok=True)
+    with open("photos/abc123.jpg", "w") as f:
+        f.write("existing")
+
+    runner = CliRunner()
+
+    # present: file already exists, so the network is never touched
+    result = runner.invoke(
+        cli, ["--email", "a@b.com", "--password", "secret", "--skip-existing"]
+    )
+    assert result.exit_code == 0
+    assert "file exists already" in result.output
+
+    # absent: skip_existing defaults to False, so it attempts the download
+    result = runner.invoke(cli, ["--email", "a@b.com", "--password", "secret"])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, RuntimeError)
+
+
+def test_empty_password_reprompts(tmp_path, monkeypatch):
+    stub_network(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["--email", "a@b.com"], input="\n\nsecret\n")
+
+    assert result.exit_code == 0
+    assert result.output.count("Password:") >= 3

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
+    { name = "click" },
     { name = "idna" },
     { name = "piexif" },
     { name = "pillow" },
@@ -87,6 +88,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "certifi", specifier = ">=2024.7.4" },
+    { name = "click", specifier = ">=8.4.2" },
     { name = "idna", specifier = ">=3.15" },
     { name = "piexif", specifier = ">=1.1.3" },
     { name = "pillow", specifier = ">=10.1.0" },


### PR DESCRIPTION
Replaces the argparse parser and its hand-rolled required-flag checks and getpass/try-except password prompt with idiomatic click options (`required=`, `envvar=`, `prompt=`/`hide_input=`). Adds `click.testing.CliRunner` test coverage for the argument-parsing surface, which previously had none.

Flag names, `.env` precedence, and the documented usage pattern in README.md are unchanged. A few edge-case behaviors differ:

- Missing `--email` now exits 2 (was 1) with click's own error wording.
- Ctrl-C during the password prompt now exits 1 (was 130); Ctrl-C during downloading is unrelated code and still exits 130 — left inconsistent rather than papered over.
- Empty password input now silently re-prompts instead of erroring after one attempt (net effect unchanged: an empty password never reaches login).
- EOF on the password prompt (no TTY) now prints click's "Aborted!" instead of a custom message; exit code stays 1.
- An explicitly empty `--password`/`BRIGHTWHEEL_PASSWORD` is now treated as a provided value and skips the prompt, unlike the old falsy-check behavior.
- `--help` output is reformatted in click's own style.