### PR TITLE
Ignore Claude Code Worktrees and Local Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,8 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json
+


### PR DESCRIPTION
Add .gitignore entries for Claude Code's local artifacts: worktree checkouts under .claude/worktrees/ and per-user overrides in .claude/settings.local.json.