### PR TITLE
Bump Version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brightwheel-photos"
-version = "1.0.0"
+version = "1.1.0"
 description = "CLI tool for downloading a student's photos from Brightwheel."
 authors = [{name = "Johnathan Gilday", email = "me@johnathangilday.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "brightwheel-photos"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Bumps the package version ahead of the next PyPI release.

Since 1.0.0: CLI migrated from Argparse to Click, dependency bumps (CVE patches, setup-uv/checkout action upgrades), Dependabot auto-merge for patch/minor bumps, and checks now run on pull requests.