### PR TITLE
Load .env From Current Working Directory

### DIFF
--- a/brightwheel_photos/cli.py
+++ b/brightwheel_photos/cli.py
@@ -10,12 +10,12 @@ import click
 import piexif
 from PIL import Image
 import requests
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 
 def main():
     """Runs brightwheel_photos cli"""
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     cli()  # pylint: disable=no-value-for-parameter
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brightwheel-photos"
-version = "1.1.0"
+version = "1.1.1"
 description = "CLI tool for downloading a student's photos from Brightwheel."
 authors = [{name = "Johnathan Gilday", email = "me@johnathangilday.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "brightwheel-photos"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
python-dotenv's default `load_dotenv()` searches upward from the installed script's location rather than the caller's working directory. Running the tool via `uv tool install` therefore ignored a project `.env` file in the directory the user actually ran it from, reporting a missing email even though `.env` was present.

Fixes it by resolving the `.env` path against the actual current working directory instead.